### PR TITLE
Fix file headers and footer for ELPA compatibility

### DIFF
--- a/flymake-lua.el
+++ b/flymake-lua.el
@@ -1,12 +1,11 @@
-;;
-;; Flymake for Lua
+;;; flymake-lua.el -- Flymake for Lua
 ;;
 ;; Usage:
 ;;   (require 'flymake-lua)
 ;;   (add-hook 'lua-mode-hook 'flymake-lua-load)
 ;;
-;; Note: litterally stolen from Steve Purcell's Flymake Ruby.
-;; See http://github.com/purcell/emacs.d/blob/master/site-lisp/flymake-ruby/flymake-ruby.el
+;; Note: literally stolen from Steve Purcell's Flymake Ruby.
+;; See http://github.com/purcell/flymake-ruby
 ;;
 
 (require 'flymake)
@@ -40,3 +39,4 @@
     (flymake-mode t)))
 
 (provide 'flymake-lua)
+;;; flymake-lua.el ends here


### PR DESCRIPTION
I'm creating a [MELPA](http://melpa.milkbox.net/) recipe for this, and the headers/footers aren't compatible with package.el -- this commit fixes them.

BTW, if you look at the latest version of [flymake-ruby](http://github.com/purcell/flymake-ruby), you'll see that I've simplified it further using my [flymake-easy](http://github.com/purcell/flymake-easy) helpers.
